### PR TITLE
Use csv rather than HTTP Request

### DIFF
--- a/app/resource/tagger/TaggerController.scala
+++ b/app/resource/tagger/TaggerController.scala
@@ -12,7 +12,7 @@ import javax.inject.Inject
 import ml.spark.NaiveBayesTagger
 import model.base.Tagger
 import play.api.Logger
-import play.api.libs.json.{JsObject, JsValue, Json}
+import play.api.libs.json.{JsValue, Json}
 import play.api.mvc._
 import task.TaskTracker
 

--- a/build.sbt
+++ b/build.sbt
@@ -24,6 +24,7 @@ libraryDependencies += "mysql" % "mysql-connector-java" % "5.1.47"
 libraryDependencies += "org.apache.hadoop" % "hadoop-client" % "2.7.2"
 
 libraryDependencies += "com.chuusai" %% "shapeless" % "2.3.3"
+libraryDependencies += "com.github.tototoshi" %% "scala-csv" % "1.3.5"
 
 libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-stream" % "2.5.21",


### PR DESCRIPTION
Creating a tagger used data from the HTTP request for training. However, I did not realize that this data is supposed to be limited. So I changed, the request to take in the filepath of a csv file, which is much more flexible as it can be a UNC path, or S3 filesystem path, etc. The underlying logic is the same, as it uses the id of the clues to look up the clue in jnode, and then trains based on the given label.